### PR TITLE
Remove python

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Tool to re-encode recursively mp3 files to any bitrate. I used this to re-encode 2TB of mp3s. It "nothing burgered" 18,966 384kbps MP3 files and went from 2,379,714,605,056 bytes to 1,275,793,204,252 bytes. There are more files to process still but this is pretty solid right now.
 
-## Install python dependencies with pip
+<!-- TODO Remove python dependencies, make it all golang-->
+<!-- TODO what it ffmpy and mutagen? -->
+## Install python dependencies with pip 
 
 ```bash
 pip install ffmpy

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ This tool will overwrite your files. Make sure you have backups prior to using f
 
 ## Contributing
 
-This program ideally should be a go install, but it has dependencies with python to pass to ffmpeg abstraction which calls either ffmpeg.exe or ffmpeg. Ideally we can just use pure go for this someday.
+This program ideally should be a go install, but it has dependencies with python to pass to ffmpeg abstraction which calls either ffmpeg.exe or ffmpeg. Ideally we can just use pure go for this someday. 

--- a/main.go
+++ b/main.go
@@ -274,6 +274,7 @@ func convertMusicFile(filename string, bitRate int) error {
 
 	// Generate the output filename
 	outputFilename := "wip-nothingburger-" + filepath.Base(filename)
+	// outputFile := filepath.Join(filepath.Dir(filename), outputFilename)
 
 	// Determine the codec and options based on the input file format
 	codec := "-c:a libmp3lame"
@@ -282,9 +283,10 @@ func convertMusicFile(filename string, bitRate int) error {
 	}
 
 	// Run FFmpeg command
-	log.Println(ffmpegPath, "-i", filename, codec, "-b:a", fmt.Sprintf("%dk", bitRate), outputFilename)
-	cmd := exec.Command(ffmpegPath, "-i", filename, codec, "-b:a", fmt.Sprintf("%dk", bitRate), outputFilename)
+	log.Println(ffmpegPath, "-i", filename, codec, "-b:a", fmt.Sprintf("%dk", bitRate), "-y", outputFilename)
+	cmd := exec.Command(ffmpegPath, "-i", filename, "-b:a", fmt.Sprintf("%dk", bitRate), "-y", outputFilename)
 	// ffmpeg -i input.mp3 -codec:a libmp3lame -b:a 128k output.mp3
+
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ func main() {
 						return
 					}
 					lockMp3sDone.RUnlock()
-					stdOut, stdErr, err := cmdExec.Run("python", "cboMP3/core/cbo_mp3.py", fileWork, bitRate)
+					stdOut, stdErr, err := cmdExec.Run("python3", "cboMP3/core/cbo_mp3.py", fileWork, bitRate)
 					if err != nil {
 						log.Println(fileWork, " Errored\n\n\n", stdOut, stdErr, err.Error())
 						return


### PR DESCRIPTION
This is work in progress:

* added 3 functions form David's promts GPT generated [code](https://chat.openai.com/share/ca1a9acb-9b3c-459b-a3f6-7c5f58f3cdac)
    * func findFFmpegExecutable() (string, error)
    * func convertMusicFile(filename string, bitRate int) error
    * func parseBitrate(output string) int

* current status:
    * it works when codec info is removed from the ffmpeg command:
    * however the command codec info works when ffmpeg command called via terminal
    * need to explore further
    
 * issue - when codec is added to the command these errors are returned:
     - [AVFormatContext @ 0x145f054f0] Unable to choose an output format for '128k'; use a standard extension for the filename or specify the format manually.
    - [out#0 @ 0x600002788240] Error initializing the muxer for 128k: Invalid argument
    - Error opening output file 128k.
    - Error opening output files: Invalid argument